### PR TITLE
Update README.md and CMDLET-REFERENCE.md to include API Reference doc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ InforcerCommunity/
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   └── workflows/            # build-and-test.yml
 ├── docs/
-│   └── CMDLET-REFERENCE.md   # Parameters and example output
+│   ├── CMDLET-REFERENCE.md   # Parameters and example output
+│   └── API-REFERENCE.md      # API schemas and response structures
 ├── CHANGELOG.md              # Release history
 ├── module/                 # Script module (see module/README.md)
 │   ├── InforcerCommunity.psd1
@@ -100,7 +101,7 @@ Disconnect-Inforcer
 | **Get-InforcerAuditEvent**     | Retrieves audit events (optional EventType, date range; -EventType has tab completion). |
 
 
-For full parameter details and example output, see **[Cmdlet Reference](docs/CMDLET-REFERENCE.md)**.
+For full parameter details and example output, see **[Cmdlet Reference](docs/CMDLET-REFERENCE.md)**. For detailed API schemas and response structures, see **[API Reference](docs/API-REFERENCE.md)**.
 
 ## Contributing
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,0 +1,448 @@
+# Inforcer API Reference
+
+This document describes the Inforcer REST API endpoints, schemas, and response structures used by the InforcerCommunity PowerShell module.
+
+> **Note**: This is a technical reference for the underlying API. For PowerShell cmdlet usage, see [CMDLET-REFERENCE.md](./CMDLET-REFERENCE.md).
+
+---
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Endpoints](#endpoints)
+  - [Baselines](#baselines)
+  - [Alignment Scores](#alignment-scores)
+  - [Tenants](#tenants)
+  - [Tenant Policies](#tenant-policies)
+  - [Audit Events](#audit-events)
+- [Schemas](#schemas)
+  - [BaselineGroup](#baselinegroup)
+  - [BaselineMember](#baselinemember)
+  - [IncludedBaselineItem](#includedbaselineitem)
+  - [AlignmentScore](#alignmentscore)
+  - [Tenant](#tenant)
+  - [TenantTag](#tenanttag)
+  - [AlignmentSummary](#alignmentsummary)
+  - [TenantLicense](#tenantlicense)
+  - [Policy](#policy)
+  - [PolicyTag](#policytag)
+  - [EventType](#eventtype)
+  - [AuditEvent](#auditevent)
+- [Response Wrapper](#response-wrapper)
+- [Error Responses](#error-responses)
+
+---
+
+## Authentication
+
+All API requests require authentication via API key. Use `Connect-Inforcer` to establish a session before calling other cmdlets.
+
+---
+
+## Endpoints
+
+### Baselines
+
+#### GET /beta/baselines
+
+Retrieves baseline groups and their members.
+
+**Cmdlet**: `Get-InforcerBaseline`
+
+| Parameter | Location | Required | Type | Description |
+|-----------|----------|----------|------|-------------|
+| baselineTenantId | query | No | integer | Filter baseline groups by baseline tenant ID. If not provided, all baseline groups are returned. |
+
+**Response**: Array of [BaselineGroup](#baselinegroup)
+
+---
+
+### Alignment Scores
+
+#### GET /beta/alignmentScores
+
+Retrieves alignment scores for tenants.
+
+**Cmdlet**: `Get-InforcerAlignmentScore`
+
+**Response**: Array of [AlignmentScore](#alignmentscore)
+
+---
+
+### Tenants
+
+#### GET /beta/tenants
+
+Retrieves all tenants.
+
+**Cmdlet**: `Get-InforcerTenant`
+
+**Response**: Array of [Tenant](#tenant)
+
+---
+
+#### GET /beta/tenants/{tenantId}
+
+Retrieves a specific tenant by ID.
+
+**Cmdlet**: `Get-InforcerTenant -TenantId`
+
+| Parameter | Location | Required | Type | Description |
+|-----------|----------|----------|------|-------------|
+| tenantId | path | Yes | integer | The unique identifier for the tenant (Client Tenant ID). |
+
+**Response**: [Tenant](#tenant)
+
+> **Implementation Note**: The PowerShell module uses `GET /beta/tenants` with client-side filtering for consistency and deduplication.
+
+---
+
+### Tenant Policies
+
+#### GET /beta/tenants/{tenantId}/policies
+
+Retrieves policies for a specific tenant.
+
+**Cmdlet**: `Get-InforcerTenantPolicies`
+
+| Parameter | Location | Required | Type | Description |
+|-----------|----------|----------|------|-------------|
+| tenantId | path | Yes | integer | The unique identifier for the tenant. |
+
+**Response**: Array of [Policy](#policy)
+
+---
+
+### Audit Events
+
+#### GET /beta/auditEvents/eventTypes
+
+Retrieves available event types for filtering audit events.
+
+**Cmdlet**: Internal use (populates `-EventType` tab completion)
+
+**Response**: Array of [EventType](#eventtype)
+
+---
+
+#### POST /beta/auditEvents/search
+
+Searches the activity log with optional filters.
+
+**Cmdlet**: `Get-InforcerAuditEvent`
+
+**Request Body**:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| eventTypes | string[] | No | Event types to filter by (e.g., `authentication`, `failedAuthentication`). |
+| dateFrom | string (date-time) | No | Start of date/time range (inclusive). ISO 8601 format. |
+| dateTo | string (date-time) | No | End of date/time range (inclusive). ISO 8601 format. |
+| pageSize | integer | No | Number of results per page. Default: 100. |
+| continuationToken | string | No | Token for pagination (returned in previous response). |
+
+**Example Request**:
+
+```json
+{
+  "eventTypes": ["authentication", "failedAuthentication"],
+  "dateFrom": "2026-02-01T00:00:00Z",
+  "dateTo": "2026-02-26T23:59:59Z",
+  "pageSize": 50
+}
+```
+
+**Response**: Paginated array of [AuditEvent](#auditevent) with `continuationToken`
+
+---
+
+## Schemas
+
+### BaselineGroup
+
+Represents a baseline configuration group used for alignment scoring.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| id | string (guid) | Unique identifier for the baseline group. |
+| name | string | Name of the baseline group. |
+| baselineClientTenantId | integer | Unique identifier for the baseline tenant (owner). |
+| baselineTenantFriendlyName | string | Display name of the baseline tenant. |
+| baselineTenantDnsName | string | DNS name of the baseline tenant (e.g., `contoso.onmicrosoft.com`). |
+| baselineMsTenantId | string (guid) | Microsoft tenant ID (Azure AD tenant ID) for the baseline tenant. |
+| alignedThreshold | number | Score threshold for "aligned" status (e.g., 80 = 80% aligned). |
+| semiAlignedThreshold | number | Score threshold for "semi-aligned" status (e.g., 60 = 60% aligned). |
+| members | [BaselineMember](#baselinemember)[] | Tenants that are members of this baseline group. |
+| mode | string | Baseline mode: `include` or `exclude`. |
+| autoAddNewPolicies | boolean | Whether new policies are automatically added to the baseline. |
+| isComplete | boolean | Whether this is a full baseline (`true`) or partial baseline (`false`). |
+| isShared | boolean | Whether this baseline is shared with other organizations. |
+| items | [IncludedBaselineItem](#includedbaselineitem)[] | Policy items explicitly configured for this baseline. `null` when using automatic inclusion rules. |
+
+---
+
+### BaselineMember
+
+Represents a tenant that is a member of a baseline group.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| clientTenantId | integer | Unique identifier for the tenant. |
+| tenantFriendlyName | string | Display name of the tenant. |
+| tenantDnsName | string | DNS name of the tenant. |
+| msTenantId | string (guid) | Microsoft tenant ID for the tenant. |
+
+---
+
+### IncludedBaselineItem
+
+Represents an item explicitly included in a custom baseline. Can reference a specific policy, nested baseline, or category-based item.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| policySnapshotId | string (guid) | Policy snapshot ID included in the baseline. |
+| childCustomBaselineId | string (guid) | Child baseline ID if this is a nested baseline item. |
+| policyCategoryProduct | string | Product category (e.g., `Intune`, `Entra`, `Defender`) for category-based items. |
+| policyCategoryPrimaryGroup | string | Primary group category (e.g., `Settings`, `Exchange`, `Windows`). Requires `policyCategoryProduct`. |
+| policyCategorySecondaryGroup | string | Secondary group category (e.g., `Custom Indicators`, `Sensitivity Labels`, `Compliance Policies`). Requires `policyCategoryProduct` and `policyCategoryPrimaryGroup`. |
+| alignAssignments | boolean | Whether policy assignments for this item should be aligned. |
+
+---
+
+### AlignmentScore
+
+Represents the alignment score for a tenant against a baseline.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| tenantId | integer | Unique identifier for the tenant. |
+| tenantFriendlyName | string | Display name of the tenant. |
+| score | number | Alignment score (0-100). |
+| baselineGroupId | string (guid) | ID of the baseline being compared against. |
+| baselineGroupName | string | Name of the baseline being compared against. |
+| lastComparisonDateTime | string (date-time) | Timestamp of the last alignment comparison. |
+
+---
+
+### Tenant
+
+Represents a tenant in the Inforcer system.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| clientTenantId | integer | Unique identifier for the tenant in Inforcer. |
+| tenantFriendlyName | string | Display name of the tenant. |
+| tenantDnsName | string | DNS name of the tenant (e.g., `contoso.onmicrosoft.com`). |
+| msTenantId | string (guid) | Microsoft tenant ID (Azure AD tenant ID). |
+| secureScore | number | Microsoft Secure Score for the tenant. |
+| isBaseline | boolean | Whether this tenant is configured as a baseline tenant. |
+| lastBackupTimestamp | string (date-time) | Timestamp of the last policy backup. |
+| recentChanges | integer | Number of recent policy changes detected. |
+| policyDiff | string | Text report of added, removed, and changed policies. |
+| tags | [TenantTag](#tenanttag)[] | Tags associated with the tenant. |
+| alignmentSummaries | [AlignmentSummary](#alignmentsummary)[] | Alignment summaries for the tenant. |
+| licenses | [TenantLicense](#tenantlicense)[] | Licenses associated with the tenant. |
+
+---
+
+### TenantTag
+
+Represents a tag associated with a tenant.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| id | string (guid) | Unique identifier for the tag. |
+| name | string | Name of the tag. |
+| description | string | Description of the tag. |
+
+---
+
+### AlignmentSummary
+
+Summary of alignment status for a tenant against a baseline.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| alignedBaselineTenantId | integer | ID of the baseline tenant. |
+| alignedBaselineId | string (guid) | ID of the aligned baseline. |
+| alignedBaselineName | string | Name of the aligned baseline. |
+| alignmentScore | number | Current alignment score (0-100). |
+| alignedThreshold | number | Threshold for "aligned" status. |
+| semiAlignedThreshold | number | Threshold for "semi-aligned" status. |
+| lastAlignmentDateTime | string (date-time) | Timestamp of the last alignment calculation. |
+
+---
+
+### TenantLicense
+
+Represents a license associated with a tenant.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| sku | string | SKU identifier of the license (e.g., `PREMIUM`, `INTUNE`). |
+
+---
+
+### Policy
+
+Represents a policy associated with a tenant.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| id | string | Unique identifier for the policy. |
+| policyTypeId | integer | Numeric ID of the policy type. |
+| name | string | Internal name of the policy. |
+| displayName | string | Display name of the policy. |
+| friendlyName | string | User-friendly name of the policy. |
+| description | string | Description of the policy. |
+| readOnly | boolean | Whether the policy is read-only (cannot be modified). |
+| product | string | Product category (e.g., `Microsoft 365`, `Intune`, `Entra`). |
+| primaryGroup | string | Primary grouping for categorization. |
+| secondaryGroup | string | Secondary grouping for categorization. |
+| platform | string | Platform the policy applies to (e.g., `Azure AD`, `Exchange`, `Windows`). |
+| policyCategoryId | integer | ID of the policy category. |
+| tags | [PolicyTag](#policytag)[] | Tags associated with the policy. |
+| policyData | object | Full policy configuration data (structure varies by policy type). |
+
+> **Note**: The PowerShell module normalizes policy names to `PolicyName` for consistency across different policy types.
+
+---
+
+### PolicyTag
+
+Represents a tag associated with a policy.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| id | string (guid) | Unique identifier for the tag. |
+| name | string | Name of the tag. |
+| description | string | Description of the tag. |
+
+---
+
+### EventType
+
+Represents a type of audit event.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| name | string | Name of the event type (e.g., `authentication`, `failedAuthentication`, `policyChange`). |
+
+---
+
+### AuditEvent
+
+Represents an entry in the activity log.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| id | string (guid) | Unique identifier for the event. |
+| correlationId | string (guid) | Correlation ID for grouping related events. |
+| clientId | integer | Client ID associated with the event. |
+| relType | string | Related entity type (e.g., `tenant`, `policy`). |
+| relId | string | Related entity ID. |
+| eventType | string | Type of event (see [EventType](#eventtype)). |
+| message | string | Human-readable event message. |
+| code | string | Event code for programmatic handling. |
+| user | string | User who triggered the event. |
+| timestamp | string (date-time) | When the event occurred. |
+| metadata | object | Additional event-specific data (flattened to top-level properties in PowerShell output). |
+
+**Flattened metadata properties** (when present):
+
+| Property | Type | Description |
+|----------|------|-------------|
+| ClientIpv4 | string | Client IPv4 address. |
+| ClientIpv6 | string | Client IPv6 address. |
+| UserName | string | Username associated with the event. |
+| UserDisplayName | string | Display name of the user. |
+
+---
+
+## Response Wrapper
+
+All API responses are wrapped in a standard envelope:
+
+```json
+{
+  "success": true,
+  "message": "optional message",
+  "errors": [],
+  "data": [ ... ]
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| success | boolean | Whether the request succeeded. |
+| message | string | Optional message about the response. |
+| errors | string[] | Array of error messages (empty on success). |
+| data | any | The response payload (array or object depending on endpoint). |
+
+The PowerShell module automatically unwraps the `data` property, so cmdlets return the payload directly.
+
+---
+
+## Error Responses
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "message": "Your credentials are invalid or you are not logged in",
+  "errors": ["Please verify your credentials"]
+}
+```
+
+**PowerShell**: Returns error "Your credentials are invalid. Please verify your API key."
+
+---
+
+### 403 Forbidden
+
+```json
+{
+  "success": false,
+  "message": "Client tenant verification failed",
+  "errors": ["You do not have access to this resource"]
+}
+```
+
+**PowerShell**: Returns error "You don't have permission to access this tenant or resource."
+
+---
+
+### 404 Not Found
+
+```json
+{
+  "success": false,
+  "message": "The resource 'derp' could not be found",
+  "errors": ["Could not find the resource"]
+}
+```
+
+**PowerShell**: Returns error "Tenant or resource not found."
+
+---
+
+### 500 Internal Server Error
+
+```json
+{
+  "success": false,
+  "message": "Something went wrong",
+  "errors": ["Internal server error"]
+}
+```
+
+**PowerShell**: Returns error with the API-provided message.
+
+---
+
+## See also
+
+- **[CMDLET-REFERENCE.md](./CMDLET-REFERENCE.md)** — PowerShell cmdlet usage and examples.
+- **[README.md](../README.md)** — Installation and quick start.
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** — How to contribute.

--- a/docs/CMDLET-REFERENCE.md
+++ b/docs/CMDLET-REFERENCE.md
@@ -2,6 +2,8 @@
 
 This document describes each cmdlet with parameters, usage examples, and **example output**.
 
+> **Tip**: For detailed property definitions and API schemas, see the [API Reference](./API-REFERENCE.md).
+
 ---
 
 ## Connect-Inforcer
@@ -88,6 +90,8 @@ When not connected, an error is written (e.g. "Not connected. To connect, run: C
 
 Retrieves tenant information. Optionally filter by `-TenantId` (Client Tenant ID or Microsoft Tenant ID GUID). Licenses are shown as a comma-separated string; PolicyDiff and PolicyDiffFormatted show policy change info when the API provides it.
 
+**Output schema**: [Tenant](./API-REFERENCE.md#tenant) — includes `tags`, `alignmentSummaries`, `licenses`
+
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|--------------|
 | **Format** | String | No | `Raw` (default). |
@@ -133,6 +137,8 @@ Same shape as one of the objects above (one tenant).
 
 Retrieves baseline groups and their members. Optionally filter by `-TenantId` (owner or member).
 
+**Output schema**: [BaselineGroup](./API-REFERENCE.md#baselinegroup) — includes `members`, `items`, alignment thresholds
+
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|--------------|
 | **Format** | String | No | `Raw` (default). |
@@ -163,6 +169,8 @@ SemiAlignedThreshold      : 60
 ## Get-InforcerTenantPolicies
 
 Retrieves policies for a specified tenant. TenantId can be Client Tenant ID (integer) or Microsoft Tenant ID (GUID).
+
+**Output schema**: [Policy](./API-REFERENCE.md#policy) — includes `product`, `platform`, `policyData`, `tags`
 
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|--------------|
@@ -203,6 +211,8 @@ Platform   : Exchange
 
 Retrieves alignment scores. **Format Table** (default): one row per alignment with columns below. **Format Raw**: raw API response. Optional `-TenantId` and `-Tag` filter the table.
 
+**Output schema**: [AlignmentScore](./API-REFERENCE.md#alignmentscore) — includes `score`, `baselineGroupId`, `lastComparisonDateTime`
+
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|--------------|
 | **Format** | String | No | `Table` (default) or `Raw`. |
@@ -236,6 +246,8 @@ A JSON string (array of objects) with properties such as `tenantId`, `tenantFrie
 ## Get-InforcerAuditEvent
 
 Retrieves audit events from the Inforcer API. Supports optional `-EventType`, `-DateFrom`, `-DateTo`, `-PageSize`, and `-MaxResults`.
+
+**Output schema**: [AuditEvent](./API-REFERENCE.md#auditevent) — includes `eventType`, `timestamp`, flattened metadata fields
 
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|-------------|
@@ -287,6 +299,7 @@ Timestamp       : 2025-03-05T14:20:00Z
 
 ## See also
 
-- **README.md** — Installation and quick start.
-- **CONTRIBUTING.md** — How to contribute and report bugs.
+- **[API-REFERENCE.md](./API-REFERENCE.md)** — Detailed API schemas and response structures.
+- **[README.md](../README.md)** — Installation and quick start.
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** — How to contribute and report bugs.
 - **Get-Help \<CmdletName\> -Full** — Full comment-based help in the module.


### PR DESCRIPTION
## Summary

- Added comprehensive API reference documentation (`docs/API-REFERENCE.md`) covering all Inforcer REST API endpoints, schemas, and response structures
- Enriched cmdlet reference with schema links so users can click through to detailed property definitions
- Updated README to reference the new API documentation

## Changes

**New file: `docs/API-REFERENCE.md`**
- Documents 7 API endpoints (`/beta/baselines`, `/beta/alignmentScores`, `/beta/tenants`, `/beta/tenants/{id}`, `/beta/tenants/{id}/policies`, `/beta/auditEvents/eventTypes`, `/beta/auditEvents/search`)
- Defines 12 schemas with property tables: `BaselineGroup`, `BaselineMember`, `IncludedBaselineItem`, `AlignmentScore`, `Tenant`, `TenantTag`, `AlignmentSummary`, `TenantLicense`, `Policy`, `PolicyTag`, `EventType`, `AuditEvent`
- Documents response wrapper structure and error responses (401, 403, 404, 500)

**Updated: `docs/CMDLET-REFERENCE.md`**
- Added tip linking to API reference
- Added "Output schema" links under each cmdlet pointing to relevant schema definitions
- Updated "See also" section

**Updated: `README.md`**
- Added `API-REFERENCE.md` to repository structure diagram
- Added link to API reference in documentation section