### PR TITLE
docs: mark CHANGELOG as v0.3.0 (2026-04-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/) and this project adheres to [Semantic Versioning](https://semver.org/). Release notes for each version are also generated from git history by the automation pipeline using the same conventional types (feat, fix, docs, refactor, test, etc.).
 
-## [Unreleased]
+## [0.3.0] - 2026-04-16
 
 ### Features
 


### PR DESCRIPTION
Replace [Unreleased] with [0.3.0] - 2026-04-16 now that release/next has been merged to main.
