### PR TITLE
fix: cross-category matching and Deployed App Count noise exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format follows [Conventional Commits](https://www.conventionalcommits.org/) and this project adheres to [Semantic Versioning](https://semver.org/). Release notes for each version are also generated from git history by the automation pipeline using the same conventional types (feat, fix, docs, refactor, test, etc.).
 
+## [0.3.2] - 2026-05-14
+
+### Bug Fixes
+
+- **Cross-category DefinitionId reconciliation** — when one tenant uses Endpoint Security templates (Disk Encryption, Antivirus, Firewall) and another uses Settings Catalog for the same settings, they land in different categories and were never compared. Added a reconciliation pass that matches unmatched settings by DefinitionId across categories, reclassifying them as Matched or Conflicting instead of SourceOnly/DestOnly.
+- **Excluded Deployed App Count from comparison** — the "Deployed App Count" setting in App Protection Policies is a tenant-specific metadata value that nobody controls. It was causing false conflicts when comparing identical MAM policies across tenants.
+
+### Tests
+
+- Added cross-category reconciliation tests (4 scenarios: matched, conflicting, no-defId fallback, same-category untouched).
+- Added noise exclusion test for Deployed App Count filtering.
+
 ## [0.3.1] - 2026-05-01
 
 ### Features

--- a/Tests/DocModel.Tests.ps1
+++ b/Tests/DocModel.Tests.ps1
@@ -1380,3 +1380,158 @@ Describe 'Compare-InforcerDocModels - BUG-04 duplicate-only exclusion' -Tag 'BUG
         $foundEnc | Should -Be $true
     }
 }
+
+Describe 'Compare-InforcerDocModels - cross-category reconciliation' -Tag 'CrossCategory' {
+    BeforeAll {
+        # Helper: builds a DocModel with explicit product and category per policy
+        $script:BuildCrossCatModel = {
+            param(
+                [string]$TenantName,
+                [string]$TenantId,
+                [array]$Policies  # each: @{ Name; Settings; Product; Category }
+            )
+            $products = [ordered]@{}
+            foreach ($p in $Policies) {
+                $prod = if ($p.Product) { $p.Product } else { 'Windows' }
+                $cat  = if ($p.Category) { $p.Category } else { 'Settings Catalog' }
+                if (-not $products.Contains($prod)) {
+                    $products[$prod] = @{ Categories = [ordered]@{} }
+                }
+                if (-not $products[$prod].Categories.Contains($cat)) {
+                    $products[$prod].Categories[$cat] = [System.Collections.Generic.List[object]]::new()
+                }
+                $policyObj = @{
+                    Basics      = @{ Name = $p.Name; ProfileType = 'Settings Catalog'; Platform = $prod }
+                    Settings    = @(
+                        $p.Settings | ForEach-Object {
+                            [PSCustomObject]@{
+                                Name         = $_.Name
+                                Value        = $_.Value
+                                Indent       = if ($null -ne $_.Indent) { $_.Indent } else { 0 }
+                                IsConfigured = if ($null -ne $_.IsConfigured) { $_.IsConfigured } else { $true }
+                                DefinitionId = $_.DefinitionId
+                            }
+                        }
+                    )
+                    Assignments = @()
+                }
+                [void]$products[$prod].Categories[$cat].Add($policyObj)
+            }
+            @{
+                TenantName = $TenantName
+                TenantId   = $TenantId
+                Products   = $products
+            }
+        }
+    }
+
+    It 'reconciles same DefinitionId across different categories as Matched' {
+        $result = InModuleScope InforcerCommunity {
+            param($buildModel)
+            $src = & $buildModel 'SourceTenant' 'src-id' @(
+                @{
+                    Name = 'BitLocker Policy'; Product = 'Windows'; Category = 'Disk Encryption'
+                    Settings = @(
+                        @{ Name = 'Require Encryption'; Value = 'Enabled'; DefinitionId = 'device_vendor_msft_bitlocker_requireencryption' }
+                    )
+                }
+            )
+            $dest = & $buildModel 'DestTenant' 'dest-id' @(
+                @{
+                    Name = 'CIS - BitLocker'; Product = 'Windows'; Category = 'Settings Catalog'
+                    Settings = @(
+                        @{ Name = 'Require Encryption'; Value = 'Enabled'; DefinitionId = 'device_vendor_msft_bitlocker_requireencryption' }
+                    )
+                }
+            )
+            Compare-InforcerDocModels -SourceModel $src -DestinationModel $dest
+        } -Parameters @{ buildModel = $script:BuildCrossCatModel }
+
+        $result.Counters.Matched | Should -Be 1
+        $result.Counters.SourceOnly | Should -Be 0
+        $result.Counters.DestOnly | Should -Be 0
+    }
+
+    It 'reconciles same DefinitionId with different values as Conflicting' {
+        $result = InModuleScope InforcerCommunity {
+            param($buildModel)
+            $src = & $buildModel 'SourceTenant' 'src-id' @(
+                @{
+                    Name = 'Firewall Policy'; Product = 'Windows'; Category = 'Firewall'
+                    Settings = @(
+                        @{ Name = 'Enable Firewall'; Value = 'True'; DefinitionId = 'device_vendor_msft_firewall_enable' }
+                    )
+                }
+            )
+            $dest = & $buildModel 'DestTenant' 'dest-id' @(
+                @{
+                    Name = 'CIS - Firewall'; Product = 'Windows'; Category = 'Settings Catalog'
+                    Settings = @(
+                        @{ Name = 'Enable Firewall'; Value = 'False'; DefinitionId = 'device_vendor_msft_firewall_enable' }
+                    )
+                }
+            )
+            Compare-InforcerDocModels -SourceModel $src -DestinationModel $dest
+        } -Parameters @{ buildModel = $script:BuildCrossCatModel }
+
+        $result.Counters.Conflicting | Should -Be 1
+        $result.Counters.SourceOnly | Should -Be 0
+        $result.Counters.DestOnly | Should -Be 0
+    }
+
+    It 'does not reconcile settings without DefinitionId (path-based keys)' {
+        $result = InModuleScope InforcerCommunity {
+            param($buildModel)
+            $src = & $buildModel 'SourceTenant' 'src-id' @(
+                @{
+                    Name = 'Policy A'; Product = 'Windows'; Category = 'Disk Encryption'
+                    Settings = @(
+                        @{ Name = 'Some Setting'; Value = 'On'; DefinitionId = '' }
+                    )
+                }
+            )
+            $dest = & $buildModel 'DestTenant' 'dest-id' @(
+                @{
+                    Name = 'Policy B'; Product = 'Windows'; Category = 'Settings Catalog'
+                    Settings = @(
+                        @{ Name = 'Some Setting'; Value = 'On'; DefinitionId = '' }
+                    )
+                }
+            )
+            Compare-InforcerDocModels -SourceModel $src -DestinationModel $dest
+        } -Parameters @{ buildModel = $script:BuildCrossCatModel }
+
+        # Without DefinitionId, cannot reconcile cross-category — stays SourceOnly + DestOnly
+        $result.Counters.SourceOnly | Should -Be 1
+        $result.Counters.DestOnly | Should -Be 1
+        $result.Counters.Matched | Should -Be 0
+    }
+
+    It 'leaves same-category matching untouched (no double-counting)' {
+        $result = InModuleScope InforcerCommunity {
+            param($buildModel)
+            $src = & $buildModel 'SourceTenant' 'src-id' @(
+                @{
+                    Name = 'Same Policy'; Product = 'Windows'; Category = 'Settings Catalog'
+                    Settings = @(
+                        @{ Name = 'Setting A'; Value = 'X'; DefinitionId = 'device_vendor_msft_setting_a' }
+                    )
+                }
+            )
+            $dest = & $buildModel 'DestTenant' 'dest-id' @(
+                @{
+                    Name = 'Same Policy'; Product = 'Windows'; Category = 'Settings Catalog'
+                    Settings = @(
+                        @{ Name = 'Setting A'; Value = 'X'; DefinitionId = 'device_vendor_msft_setting_a' }
+                    )
+                }
+            )
+            Compare-InforcerDocModels -SourceModel $src -DestinationModel $dest
+        } -Parameters @{ buildModel = $script:BuildCrossCatModel }
+
+        # Already matched in same category — no cross-category needed
+        $result.Counters.Matched | Should -Be 1
+        $result.Counters.SourceOnly | Should -Be 0
+        $result.Counters.DestOnly | Should -Be 0
+    }
+}

--- a/Tests/DocModel.Tests.ps1
+++ b/Tests/DocModel.Tests.ps1
@@ -779,6 +779,16 @@ Describe 'Compare-InforcerDocModels - ENG-01 noise exclusion' -Tag 'ENG-01' {
         $result.Products.Windows.Categories.'Settings Catalog'.ComparisonRows | Should -HaveCount 1
     }
 
+    It 'excludes Deployed App Count setting from comparison output' {
+        $result = InModuleScope InforcerCommunity {
+            param($buildModel)
+            $src  = & $buildModel 'Deployed App Count' '37' 'Source' 'src-id'
+            $dest = & $buildModel 'Deployed App Count' '40' 'Dest'   'dest-id'
+            Compare-InforcerDocModels -SourceModel $src -DestinationModel $dest
+        } -Parameters @{ buildModel = $buildModelWithSetting }
+        $result.Products.Windows.Categories.'Settings Catalog'.ComparisonRows | Should -HaveCount 0
+    }
+
     It 'does not exclude non-standalone GUID text from comparison output' {
         $result = InModuleScope InforcerCommunity {
             param($buildModel)

--- a/module/InforcerCommunity.psd1
+++ b/module/InforcerCommunity.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'InforcerCommunity.psm1'
-    ModuleVersion     = '0.3.1'
+    ModuleVersion     = '0.3.2'
     GUID              = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
     Author            = 'Roy Klooster'
     Description       = 'Community PowerShell module for the Inforcer API. Created by Roy Klooster. Not owned or officially maintained by Inforcer.'

--- a/module/InforcerCommunity.psd1
+++ b/module/InforcerCommunity.psd1
@@ -31,7 +31,7 @@
         PSData = @{
             ProjectUri   = 'https://github.com/royklo/InforcerCommunity'
             LicenseUri   = 'https://github.com/royklo/InforcerCommunity/blob/main/LICENSE'
-            ReleaseNotes = 'Community module for the Inforcer API. Renamed to InforcerCommunity; consistency tests; gallery-ready metadata.'
+            ReleaseNotes = 'v0.3.2: Cross-category DefinitionId reconciliation for mixed Endpoint Security/Settings Catalog comparisons. Excluded Deployed App Count as tenant-specific noise.'
             Tags         = @('Inforcer', 'API', 'Community')
         }
     }

--- a/module/Private/Compare-InforcerDocModels.ps1
+++ b/module/Private/Compare-InforcerDocModels.ps1
@@ -62,6 +62,7 @@ function Compare-InforcerDocModels {
         'Onboarding Blob'
         'Tenant Id'
         'Tenant Id (Device)'
+        'Deployed App Count'
     )
 
     # App protection: settings that enumerate individual app IDs (noise)

--- a/module/Private/Compare-InforcerDocModels.ps1
+++ b/module/Private/Compare-InforcerDocModels.ps1
@@ -599,15 +599,6 @@ function Compare-InforcerDocModels {
                         [void]$usedRemSrc.Add($candidate.Si)
                         [void]$usedRemDst.Add($candidate.Di)
                     }
-                    # Leftover unmatched
-                    $extraSrc = [System.Collections.Generic.List[object]]::new()
-                    $extraDst = [System.Collections.Generic.List[object]]::new()
-                    for ($si = 0; $si -lt $remainingSrc.Count; $si++) {
-                        if (-not $usedRemSrc.Contains($si)) { [void]$extraSrc.Add($remainingSrc[$si]) }
-                    }
-                    for ($di = 0; $di -lt $remainingDst.Count; $di++) {
-                        if (-not $usedRemDst.Contains($di)) { [void]$extraDst.Add($remainingDst[$di]) }
-                    }
 
                     # Helper: disambiguate policy name when duplicates exist (append short ID)
                     $disambiguateName = {
@@ -637,11 +628,12 @@ function Compare-InforcerDocModels {
                         $dstLookup = & $buildSettingLookup $dstPolicy.Settings
 
                         $allSettingKeys = [System.Collections.Generic.List[string]]::new()
+                        $seenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                         foreach ($k in $srcLookup.Keys) {
-                            if (-not $allSettingKeys.Contains($k)) { [void]$allSettingKeys.Add($k) }
+                            if ($seenKeys.Add($k)) { [void]$allSettingKeys.Add($k) }
                         }
                         foreach ($k in $dstLookup.Keys) {
-                            if (-not $allSettingKeys.Contains($k)) { [void]$allSettingKeys.Add($k) }
+                            if ($seenKeys.Add($k)) { [void]$allSettingKeys.Add($k) }
                         }
 
                         foreach ($settingKey in $allSettingKeys) {
@@ -695,12 +687,12 @@ function Compare-InforcerDocModels {
                         $groupPolicies = [System.Collections.Generic.List[object]]::new()
                         foreach ($p in $srcList) {
                             $pName = & $disambiguateName $p $true
-                            $settingCount = @($p.Settings | Where-Object { $_.IsConfigured -eq $true }).Count
+                            $settingCount = 0; foreach ($s in $p.Settings) { if ($s.IsConfigured -eq $true) { $settingCount++ } }
                             [void]$groupPolicies.Add(@{ Name = $pName; Side = 'Source'; SettingCount = $settingCount; Id = $p.Basics.Id })
                         }
                         foreach ($p in $dstList) {
                             $pName = & $disambiguateName $p $true
-                            $settingCount = @($p.Settings | Where-Object { $_.IsConfigured -eq $true }).Count
+                            $settingCount = 0; foreach ($s in $p.Settings) { if ($s.IsConfigured -eq $true) { $settingCount++ } }
                             [void]$groupPolicies.Add(@{ Name = $pName; Side = 'Destination'; SettingCount = $settingCount; Id = $p.Basics.Id })
                         }
                         [void]$duplicatePolicies.Add(@{
@@ -1372,7 +1364,6 @@ function Compare-InforcerDocModels {
         AlignmentScore       = $alignmentScore
         TotalItems           = $totalItems
         Counters             = $counters
-        DeprecatedSettings   = @()  # deprecated policies are now in ManualReview with HasDeprecated flag
         Products             = $products
         ManualReview         = $manualReview
         DuplicatePolicies    = $duplicatePolicies

--- a/module/Private/Compare-InforcerDocModels.ps1
+++ b/module/Private/Compare-InforcerDocModels.ps1
@@ -663,18 +663,20 @@ function Compare-InforcerDocModels {
                                 $status = 'DestOnly'
                             }
 
+                            $refEntry = if ($inSrc) { $srcLookup[$settingKey] } else { $dstLookup[$settingKey] }
                             $row = @{
-                                ItemType     = 'Setting'
-                                Name         = $displayName
-                                SettingPath  = if ($inSrc) { $srcLookup[$settingKey].SettingPath } else { $dstLookup[$settingKey].SettingPath }
-                                LookupKey    = $settingKey
-                                Category     = $categoryLabel
-                                Status       = $status
-                                SourcePolicy = $srcPolicyName
-                                SourceValue  = $srcVal
-                                DestPolicy   = $dstPolicyName
-                                DestValue    = $dstVal
-                                IsDeprecated = if ($inSrc) { $srcLookup[$settingKey].IsDeprecated -eq $true } else { $dstLookup[$settingKey].IsDeprecated -eq $true }
+                                ItemType        = 'Setting'
+                                Name            = $displayName
+                                SettingPath     = $refEntry.SettingPath
+                                LookupKey       = $settingKey
+                                HasDefinitionId = -not [string]::IsNullOrEmpty($refEntry.DefinitionId)
+                                Category        = $categoryLabel
+                                Status          = $status
+                                SourcePolicy    = $srcPolicyName
+                                SourceValue     = $srcVal
+                                DestPolicy      = $dstPolicyName
+                                DestValue       = $dstVal
+                                IsDeprecated    = $refEntry.IsDeprecated -eq $true
                             }
                             if ($IncludingAssignments) {
                                 $row.SourceAssignment = $srcAssignStr
@@ -721,17 +723,18 @@ function Compare-InforcerDocModels {
                             if (& $isEmptyValue $srcVal) { continue }
 
                             $row = @{
-                                ItemType     = 'Setting'
-                                Name         = $srcLookup[$settingKey].Name
-                                SettingPath  = $srcLookup[$settingKey].SettingPath
-                                LookupKey    = $settingKey
-                                Category     = $categoryLabel
-                                Status       = 'SourceOnly'
-                                SourcePolicy = $srcPolicyName
-                                SourceValue  = $srcVal
-                                DestPolicy   = ''
-                                DestValue    = ''
-                                IsDeprecated = $srcLookup[$settingKey].IsDeprecated -eq $true
+                                ItemType        = 'Setting'
+                                Name            = $srcLookup[$settingKey].Name
+                                SettingPath     = $srcLookup[$settingKey].SettingPath
+                                LookupKey       = $settingKey
+                                HasDefinitionId = -not [string]::IsNullOrEmpty($srcLookup[$settingKey].DefinitionId)
+                                Category        = $categoryLabel
+                                Status          = 'SourceOnly'
+                                SourcePolicy    = $srcPolicyName
+                                SourceValue     = $srcVal
+                                DestPolicy      = ''
+                                DestValue       = ''
+                                IsDeprecated    = $srcLookup[$settingKey].IsDeprecated -eq $true
                             }
                             if ($IncludingAssignments) {
                                 $row.SourceAssignment = $srcAssignStr
@@ -755,17 +758,18 @@ function Compare-InforcerDocModels {
                             if (& $isEmptyValue $dstVal) { continue }
 
                             $row = @{
-                                ItemType     = 'Setting'
-                                Name         = $dstLookup[$settingKey].Name
-                                SettingPath  = $dstLookup[$settingKey].SettingPath
-                                LookupKey    = $settingKey
-                                Category     = $categoryLabel
-                                Status       = 'DestOnly'
-                                SourcePolicy = ''
-                                SourceValue  = ''
-                                DestPolicy   = $dstPolicyName
-                                DestValue    = $dstVal
-                                IsDeprecated = $dstLookup[$settingKey].IsDeprecated -eq $true
+                                ItemType        = 'Setting'
+                                Name            = $dstLookup[$settingKey].Name
+                                SettingPath     = $dstLookup[$settingKey].SettingPath
+                                LookupKey       = $settingKey
+                                HasDefinitionId = -not [string]::IsNullOrEmpty($dstLookup[$settingKey].DefinitionId)
+                                Category        = $categoryLabel
+                                Status          = 'DestOnly'
+                                SourcePolicy    = ''
+                                SourceValue     = ''
+                                DestPolicy      = $dstPolicyName
+                                DestValue       = $dstVal
+                                IsDeprecated    = $dstLookup[$settingKey].IsDeprecated -eq $true
                             }
                             if ($IncludingAssignments) {
                                 $row.SourceAssignment = ''
@@ -794,8 +798,7 @@ function Compare-InforcerDocModels {
                 $defId = $row.LookupKey
                 if ([string]::IsNullOrEmpty($defId)) { continue }
                 # Only index rows keyed by DefinitionId (not SettingPath fallbacks)
-                # DefinitionIds never contain spaces; SettingPaths always do
-                if ($defId -match '\s') { continue }
+                if (-not $row.HasDefinitionId) { continue }
 
                 if ($row.Status -eq 'SourceOnly') {
                     if (-not $sourceOnlyByDefId.Contains($defId)) {

--- a/module/Private/Compare-InforcerDocModels.ps1
+++ b/module/Private/Compare-InforcerDocModels.ps1
@@ -779,6 +779,87 @@ function Compare-InforcerDocModels {
         }
     }
 
+    # ── Cross-category reconciliation ────────────────────────────────────
+    # When the same Intune setting (same DefinitionId) is delivered via different
+    # policy types (e.g., Endpoint Security template vs Settings Catalog), they
+    # land in different categories and both appear as SourceOnly / DestOnly.
+    # This pass matches them by DefinitionId and reclassifies as Matched/Conflicting.
+    $sourceOnlyByDefId = [ordered]@{}   # defId -> @{ Row; Product; Category }
+    $destOnlyByDefId   = [ordered]@{}
+
+    foreach ($prodName in @($products.Keys)) {
+        foreach ($catName in @($products[$prodName].Categories.Keys)) {
+            foreach ($row in $products[$prodName].Categories[$catName].ComparisonRows) {
+                $defId = $row.LookupKey
+                if ([string]::IsNullOrEmpty($defId)) { continue }
+                # Only index rows keyed by DefinitionId (not SettingPath fallbacks)
+                # DefinitionIds never contain spaces; SettingPaths always do
+                if ($defId -match '\s') { continue }
+
+                if ($row.Status -eq 'SourceOnly') {
+                    if (-not $sourceOnlyByDefId.Contains($defId)) {
+                        $sourceOnlyByDefId[$defId] = [System.Collections.Generic.List[object]]::new()
+                    }
+                    [void]$sourceOnlyByDefId[$defId].Add(@{
+                        Row      = $row
+                        Product  = $prodName
+                        Category = $catName
+                    })
+                }
+                elseif ($row.Status -eq 'DestOnly') {
+                    if (-not $destOnlyByDefId.Contains($defId)) {
+                        $destOnlyByDefId[$defId] = [System.Collections.Generic.List[object]]::new()
+                    }
+                    [void]$destOnlyByDefId[$defId].Add(@{
+                        Row      = $row
+                        Product  = $prodName
+                        Category = $catName
+                    })
+                }
+            }
+        }
+    }
+
+    # Match SourceOnly <-> DestOnly by shared DefinitionId
+    foreach ($defId in $sourceOnlyByDefId.Keys) {
+        if (-not $destOnlyByDefId.Contains($defId)) { continue }
+
+        $srcEntries = $sourceOnlyByDefId[$defId]
+        $dstEntries = $destOnlyByDefId[$defId]
+
+        # Pair 1:1 positionally (typically one source, one dest per defId)
+        $pairCount = [math]::Min($srcEntries.Count, $dstEntries.Count)
+        for ($i = 0; $i -lt $pairCount; $i++) {
+            $srcEntry = $srcEntries[$i]
+            $dstEntry = $dstEntries[$i]
+            $srcRow = $srcEntry.Row
+            $dstRow = $dstEntry.Row
+
+            # Determine new status
+            $newStatus = if ($srcRow.SourceValue -eq $dstRow.DestValue) { 'Matched' } else { 'Conflicting' }
+
+            # Update the source row in-place to become the reconciled row
+            $srcRow.Status     = $newStatus
+            $srcRow.DestPolicy = $dstRow.DestPolicy
+            $srcRow.DestValue  = $dstRow.DestValue
+            if ($srcRow.ContainsKey('DestAssignment') -and $dstRow.ContainsKey('DestAssignment')) {
+                $srcRow.DestAssignment = $dstRow.DestAssignment
+            }
+
+            # Update counters: source row was SourceOnly, now is Matched/Conflicting
+            $counters['SourceOnly']--
+            $counters[$newStatus]++
+            $products[$srcEntry.Product].Counters['SourceOnly']--
+            $products[$srcEntry.Product].Counters[$newStatus]++
+
+            # Remove the dest row from its original category
+            $dstRows = $products[$dstEntry.Product].Categories[$dstEntry.Category].ComparisonRows
+            [void]$dstRows.Remove($dstRow)
+            $counters['DestOnly']--
+            $products[$dstEntry.Product].Counters['DestOnly']--
+        }
+    }
+
     # ── Manual Review = script/remediation/custom compliance + deprecated ──
     $manualReview = $manualReviewCategories
 


### PR DESCRIPTION
Summary                                                                                                                                                                                
                                                                                                                                                                                         
  - Cross-category DefinitionId reconciliation — when one tenant uses Endpoint Security templates (Disk Encryption, Antivirus, Firewall) and another uses Settings Catalog for the same settings, they land in different categories and were never compared. Added a reconciliation pass that matches unmatched settings by DefinitionId across categories, reclassifying them as Matched or Conflicting instead of SourceOnly/DestOnly.                                                                                                                            
  - Excluded "Deployed App Count" from comparison — tenant-specific metadata in App Protection Policies that caused false conflicts between identical MAM policies.                      
  - Version bump to 0.3.2 with updated changelog.
                                                                                                                                                                                         
  Test plan                                                                                                                                                                            
                                      
  - 66/66 DocModel tests pass (including 4 new cross-category tests + 1 noise exclusion test)                                                                                            
  - 69/69 Consistency tests pass
  - Run Compare-InforcerEnvironments with tenants using mixed Endpoint Security + Settings Catalog templates — cross category settings should reconcile correctly                        
  - Run comparison with identical tenants — "Deployed App Count" should no longer appear as conflicts